### PR TITLE
CI: Bump ubuntu runner to 24.04.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
       uses: carlosperate/arm-none-eabi-gcc-action@v1
       with:
-        release: '12.2.Rel1'
+        release: '13.3.Rel1'
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -101,22 +101,12 @@ jobs:
 
     - name: Upload .zip
       if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      uses: softprops/action-gh-release@v1
       with:
-        asset_path: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.zip
-        upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{env.RELEASE_FILE}}.zip
-        asset_content_type: application/zip
+        files: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.zip
 
     - name: Upload .tar.gz
       if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      uses: softprops/action-gh-release@v1
       with:
-        asset_path: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.tar.gz
-        upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{env.RELEASE_FILE}}.tar.gz
-        asset_content_type: application/octet-stream
+        files: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.tar.gz

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         repository: raspberrypi/pico-sdk
         path: pico-sdk
-        ref: 2.0.0
+        ref: '2.1.1'
         submodules: true
 
     # Checkout Pico Extras

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         repository: raspberrypi/pico-extras
         path: pico-extras
-        ref: sdk-2.0.0
+        ref: sdk-2.1.1
         submodules: true
 
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             name: Linux
             cache-key: linux
             cmake-args: '-DPIMORONI_PICO_PATH=$GITHUB_WORKSPACE/pimoroni-pico -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -64,6 +64,18 @@ jobs:
       with:
         release: '13.3.Rel1'
 
+    # CMake 4.0 - erroneously introduced into GitHub runners? -
+    # removed support for <3.5 and mbedtls hits this
+    # https://github.com/raspberrypi/pico-sdk/issues/2391
+    # https://github.com/actions/runner-images/issues/11926
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.31.6'
+
+    - name: CMake Version
+      run: cmake --version
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13...3.27)
 
 set(NAME picade-max-audio)
 set(FAMILY rp2040)


### PR DESCRIPTION
Deprecation began today and ubuntu-20.04 will be unavailable from 2025-04-15.

Don't use "ubuntu-latest" since CI might quietly break in future.